### PR TITLE
6502: don't #include malloc.h on macOS

### DIFF
--- a/6502.c
+++ b/6502.c
@@ -19,7 +19,9 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
+#ifndef __MACH__
 #include <malloc.h>
+#endif
 
 #define _6502_PRIVATE
 #include "6502.h"


### PR DESCRIPTION
There is no `malloc.h` on macOS (`stdlib.h` is enough), so compilation breaks.