### PR TITLE
Makefile: rm dependancy which has no rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ rc2014-6502: rc2014-6502.o 6502.o 6502dis.o
 rc2014-8085: rc2014-8085.o intel_8085_emulator.o ide.o acia.o w5100.o ppide.o rtc_bitbang.o
 	cc -g3 rc2014-8085.o acia.o ide.o ppide.o rtc_bitbang.o w5100.o intel_8085_emulator.o -o rc2014-8085
 
-rc2014-80c188: rc2014-80c188.o 80x86/*.o ide.o w5100.o ppide.o rtc_bitbang.o
+rc2014-80c188: rc2014-80c188.o ide.o w5100.o ppide.o rtc_bitbang.o
 	(cd 80x86; make)
 	cc -g3 rc2014-80c188.o ide.o ppide.o rtc_bitbang.o w5100.o 80x86/*.o -o rc2014-80c188
 


### PR DESCRIPTION
When tree is clean,  make on macOS fails with 

```make: *** No rule to make target `80x86/*.o', needed by `rc2014-80c188'.  Stop.```

(also, we don't have 80x86/*.o as dependency on other targets, and we have `cd 80x86; make` anyway)