### PR TITLE
Update mbc2.c to  have a functional -s option for selecting diskset

### DIFF
--- a/mbc2.c
+++ b/mbc2.c
@@ -400,7 +400,6 @@ int main(int argc, char *argv[])
 {
 	static struct timespec tc;
 	int opt;
-	int diskset;
 	int fd;
 	int l;
 	int fast;


### PR DESCRIPTION
the variable diskset is firstly in line 29 at as int. But when diskset is set to int also in the deleted line the result will always be that diskset 0 is selected.
While commenting out or delete the line the -s option does select the right diskset (like -s3 for the CP/ 3.0 diskset)
I did found the "patch" in the thread 
https://forum.classic-computing.de/forum/index.php?thread/18832-kennt-jemand-den-z80-mbc2/&postID=215650#post215650
and without that "patch" I only could load CP/M 2.2 because this is using the diskset 0
After compiling the mbc2.c (make mbc2) with this line deleted the diskset selection did work for the original user ngc224 and me.