### PR TITLE
Tweaks to remove warnings/errors for Mac OS X build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.o
 .DS_Store
 *.swp
+*.BIN
+my.cf
 
 lib765/lib/lib765.a
 *.dSYM

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 *.o
+.DS_Store
+*.swp
 
+lib765/lib/lib765.a
+*.dSYM
+flexbox
 lib65c816/config/sizeof
 lib65c816/lib65816/config.h
 lib65c816/src/lib65816.a

--- a/6800.c
+++ b/6800.c
@@ -1625,7 +1625,7 @@ static int m6800_execute_one(struct m6800 *cpu)
             }
             if (tmp8 <= 0x03 && tmp2 <= 0x03 && (cpu->p & P_H)) {
                 tmpc = 1;
-                add =- 0x66;
+                add = -0x66;
             }
         }
         cpu->a += add;

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ clean:
 	$(MAKE) --directory m68k clean && \
 	rm -f *.o *~ rc2014 rbcv2
 
-SRCS := $(subst ./,,$(shell find -name '*.c'))
+SRCS := $(subst ./,,$(shell find . -name '*.c'))
 DEPDIR := .deps
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.d
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,8 @@ z80mb64)
 
 To build a disk image
 
-./makedisk 1 my.cf
-
-dd if=cf-image of=my.cf bs=512 seek=2 conv=notrunc
+    #  ./makedisk 1 my.cf
+    #  dd if=cf-image of=my.cf bs=512 seek=2 conv=notrunc
 
 In other words the IDE disk format has a 1K header that holds
 meta-data and the virtual identify block.
@@ -84,6 +83,18 @@ the system will save the full memory image back to the ROM file (unless
 marked read only), so you can do the full bootstrap. Alternatively you can
 start from the SCM monitor or similar. These boards default to the bitbang
 serial interface, unless an SIO or ACIA is specified.
+
+As an example, to get going on this, follow these steps:
+
+
+    #  make rc2014
+    #  ./rc2014 -p -i my.cf -s -r ../24886009.BIN  -e 2
+
+This will start up for CP/M on a RC2014, using the "my.cf" disk image setup above.
+It will start you up in the Small Computer Monitor.  To start up CPM, type:
+
+    *  cpm
+
 
 # RBC (ex N8VEM) Mark 2 Emulator
 

--- a/lib65c816/src/debugger.c
+++ b/lib65c816/src/debugger.c
@@ -311,10 +311,10 @@ void CPU_debug(void) {
         case BLK:
             sprintf( operands, "$%02X, $%02X (@%06X:%02X -> @%06X:%02X)",
                 DB_READ(PC.A+2), DB_READ(PC.A+1),
-                DB_READ(PC.A+2) << 16 + X.W,
-                DB_READ(DB_READ(PC.A+2) << 16 + X.W),
-                DB_READ(PC.A+1) << 16 + Y.W,
-                DB_READ(DB_READ(PC.A+2) << 16 + Y.W)
+                DB_READ(PC.A+2) << (16 + X.W),
+                DB_READ(DB_READ(PC.A+2) << (16 + X.W)),
+                DB_READ(PC.A+1) << (16 + Y.W),
+                DB_READ(DB_READ(PC.A+2) << (16 + Y.W))
             );
             break;
 	}

--- a/linc80.c
+++ b/linc80.c
@@ -783,7 +783,7 @@ static uint8_t sd_process_command(void)
 		sd_lba = sd_cmd[4] + 256 * sd_cmd[3] + 65536 * sd_cmd[2] +
 			16777216 * sd_cmd[1];
 		if (trace & TRACE_SD)
-			fprintf(stderr, "Read LBA %lx\n", sd_lba);
+			fprintf(stderr, "Read LBA %llx\n", sd_lba);
 		if (lseek(sd_fd, sd_lba, SEEK_SET) < 0 || read(sd_fd, sd_out + 2, 512) != 512) {
 			if (trace & TRACE_SD)
 				fprintf(stderr, "Read LBA failed.\n");
@@ -795,7 +795,7 @@ static uint8_t sd_process_command(void)
 	case 0x40+24:		/* Write */
 		/* Will send us FE data FF FF */
 		if (trace & TRACE_SD)
-			fprintf(stderr, "Write LBA %lx\n", sd_lba);
+			fprintf(stderr, "Write LBA %llx\n", sd_lba);
 		sd_inlen = 514;	/* Data FF FF */
 		sd_lba = sd_cmd[4] + 256 * sd_cmd[3] + 65536 * sd_cmd[2] +
 			16777216 * sd_cmd[1];

--- a/rc2014-65c816-mini.c
+++ b/rc2014-65c816-mini.c
@@ -46,7 +46,7 @@ static uint16_t tstate_steps = 200;
 
 static nic_w5100_t *wiz;
 
-static volatile int done;
+/* static volatile int done; */
 
 #define TRACE_MEM	1
 #define TRACE_IO	2

--- a/rc2014-68008.c
+++ b/rc2014-68008.c
@@ -46,7 +46,7 @@ static uint16_t tstate_steps = 200;
 
 static nic_w5100_t *wiz;
 
-static volatile int done;
+/* static volatile int done; */
 
 #define TRACE_MEM	1
 #define TRACE_IO	2

--- a/rc2014.c
+++ b/rc2014.c
@@ -1464,7 +1464,7 @@ static uint8_t sd_process_command(void)
 		sd_lba = sd_cmd[4] + 256 * sd_cmd[3] + 65536 * sd_cmd[2] +
 			16777216 * sd_cmd[1];
 		if (trace & TRACE_SD)
-			fprintf(stderr, "Read LBA %lx\n", sd_lba);
+			fprintf(stderr, "Read LBA %llx\n", sd_lba);
 		if (lseek(sd_fd, sd_lba, SEEK_SET) < 0 || read(sd_fd, sd_out + 2, 512) != 512) {
 			if (trace & TRACE_SD)
 				fprintf(stderr, "Read LBA failed.\n");
@@ -1476,7 +1476,7 @@ static uint8_t sd_process_command(void)
 	case 0x40+24:		/* Write */
 		/* Will send us FE data FF FF */
 		if (trace & TRACE_SD)
-			fprintf(stderr, "Write LBA %lx\n", sd_lba);
+			fprintf(stderr, "Write LBA %llx\n", sd_lba);
 		sd_inlen = 514;	/* Data FF FF */
 		sd_lba = sd_cmd[4] + 256 * sd_cmd[3] + 65536 * sd_cmd[2] +
 			16777216 * sd_cmd[1];

--- a/z80mc.c
+++ b/z80mc.c
@@ -155,7 +155,7 @@ static uint8_t sd_process_command(void)
 		sd_lba = sd_cmd[4] + 256 * sd_cmd[3] + 65536 * sd_cmd[2] +
 			16777216 * sd_cmd[1];
 		if (trace & TRACE_SD)
-			fprintf(stderr, "Read LBA %lx\n", sd_lba);
+			fprintf(stderr, "Read LBA %llx\n", sd_lba);
 		if (lseek(sd_fd, sd_lba, SEEK_SET) < 0 || read(sd_fd, sd_out + 2, 512) != 512) {
 			if (trace & TRACE_SD)
 				fprintf(stderr, "Read LBA failed.\n");
@@ -167,7 +167,7 @@ static uint8_t sd_process_command(void)
 	case 0x40+24:		/* Write */
 		/* Will send us FE data FF FF */
 		if (trace & TRACE_SD)
-			fprintf(stderr, "Write LBA %lx\n", sd_lba);
+			fprintf(stderr, "Write LBA %llx\n", sd_lba);
 		sd_inlen = 514;	/* Data FF FF */
 		sd_lba = sd_cmd[4] + 256 * sd_cmd[3] + 65536 * sd_cmd[2] +
 			16777216 * sd_cmd[1];


### PR DESCRIPTION
Hey.  I tried to build your emulator on my Mac (running MacOS 10.15.2) and got a few errors that killed the build process.  I made some tweaks here and there that probably won't affect builds for other platforms, (linux, etc), but I have no way to test them.  
 
As a sidenote, thank you for building with -Wall -pedantic -Werror  :D

Enjoy and have a great day! 😄 