### PR TITLE
m68k: Fix sprintf() compile error

### DIFF
--- a/m68k/m68kdasm.c
+++ b/m68k/m68kdasm.c
@@ -325,7 +325,7 @@ static char* make_signed_hex_str_32(uint val)
 /* make string of immediate value */
 static char* get_imm_str_s(uint size)
 {
-	static char str[15];
+	static char str[25];
 	if(size == 0)
 		sprintf(str, "#%s", make_signed_hex_str_8(read_imm_8()));
 	else if(size == 1)


### PR DESCRIPTION
gcc 9.3.0 produces the following error and note during compile:

m68kdasm.c:334:18: error: ‘%s’ directive writing up to 19 bytes into a region of size 14
note: ‘sprintf’ output between 2 and 21 bytes into a destination of size 15

Increase the str array to 25 bytes.