### PR TITLE
Fixing GCC compile errors

### DIFF
--- a/intel_8085_emulator.c
+++ b/intel_8085_emulator.c
@@ -41,6 +41,8 @@
 #define reg16_DE (((uint16_t)reg8[D] << 8) | (uint16_t)reg8[E])
 #define reg16_HL (((uint16_t)reg8[H] << 8) | (uint16_t)reg8[L])
 
+FILE *i8085_log;
+
 uint8_t reg8[9], INTE = 0;
 uint16_t reg_SP, reg_PC;
 uint8_t reg_IM = 0x07;	/* Verified with a Tundra CA80C85B */

--- a/intel_8085_emulator.h
+++ b/intel_8085_emulator.h
@@ -38,6 +38,6 @@ extern void i8085_reset();
 
 extern int i8085_exec(int cycles);
 
-FILE *i8085_log;
+extern FILE *i8085_log;
 
 #endif

--- a/m68k/m68kdasm.c
+++ b/m68k/m68kdasm.c
@@ -325,7 +325,7 @@ static char* make_signed_hex_str_32(uint val)
 /* make string of immediate value */
 static char* get_imm_str_s(uint size)
 {
-	static char str[15];
+	static char str[22];
 	if(size == 0)
 		sprintf(str, "#%s", make_signed_hex_str_8(read_imm_8()));
 	else if(size == 1)


### PR DESCRIPTION
Fixed two compile errors with GCC 10.2.0-15.

First is a possible overflow error with sprintf in m68kdasm.c:

```
m68kdasm.c: In function ‘get_imm_str_s.part.0’:
m68kdasm.c:334:18: error: ‘%s’ directive writing up to 19 bytes into a region of size 14 [-Werror=format-overflow=]
```

The second one was the linker complaining about multiple declarations of i8085_log:

```
/usr/bin/ld: intel_8085_emulator.o:/home/bastetfurry/Compile/RC2014/intel_8085_emulator.h:41: multiple definition of `i8085_log'; rc2014-8085.o:/home/bastetfurry/Compile/RC2014/intel_8085_emulator.h:41: first defined here
```