### PR TITLE
Fix out of bounds sprintf issue in newer GCCs

### DIFF
--- a/m68k/m68kdasm.c
+++ b/m68k/m68kdasm.c
@@ -307,7 +307,7 @@ static char* make_signed_hex_str_16(uint val)
 
 static char* make_signed_hex_str_32(uint val)
 {
-	static char str[20];
+	static char str[11];
 
 	val &= 0xffffffff;
 


### PR DESCRIPTION
make_signed_hex_str_32() allocates 20 bytes for its return string. It will never use as much, but get_imm_str_s() merges it into a string of only 15 bytes, making gcc 10.2 throw an error.

Changed the string size in make_signed_hex_str_32() to the maximum possible value to avoid this error.