### PR TITLE
Z80: exit simulator on halt.

### DIFF
--- a/rc2014.c
+++ b/rc2014.c
@@ -3207,6 +3207,10 @@ int main(int argc, char *argv[])
 	/* We run 365 cycles per I/O check, do that 50 times then poll the
 	   slow stuff and nap for 20ms to get 50Hz on the TMS99xx */
 	while (!emulator_done) {
+		if (cpu_z80.halted) {
+			emulator_done = 1;
+			break;
+		}
 		int i;
 		/* 36400 T states for base RC2014 - varies for others */
 		for (i = 0; i < 50; i++) {


### PR DESCRIPTION
To use the simulator for automated testing, it is helpful if the Z80 HALT instruction results in terminating the simulation. This patch does that, but for the basic RC2014 only.