### PR TITLE
Z80: exit simulator on halt with interrupts disabled.

### DIFF
--- a/rc2014.c
+++ b/rc2014.c
@@ -3207,6 +3207,13 @@ int main(int argc, char *argv[])
 	/* We run 365 cycles per I/O check, do that 50 times then poll the
 	   slow stuff and nap for 20ms to get 50Hz on the TMS99xx */
 	while (!emulator_done) {
+		if (cpu_z80.halted && ! cpu_z80.IFF1) {
+			/* HALT with interrupts disabled, so nothing left
+			   to do, so exit simulation. If NMI was supported,
+			   this might have to change. */
+			emulator_done = 1;
+			break;
+		}
 		int i;
 		/* 36400 T states for base RC2014 - varies for others */
 		for (i = 0; i < 50; i++) {


### PR DESCRIPTION
For the Z80-based RC2014 only, end simulation if a halt instruction is executed with interrupts disabled.
The RC2014 doesn't currently support non-maskable interrupts; if that happens in the future, this might need to be changed to a different mechanism, as EtchedPixels described in pull request https://github.com/EtchedPixels/RC2014/pull/31.