### PR TITLE
Set DUART IVR to 0xF at reset.

### DIFF
--- a/duart.c
+++ b/duart.c
@@ -208,6 +208,7 @@ void duart_reset(struct duart *d)
 	d->acr = 0xFF;
 	d->isr = 0;
 	d->imr = 0;
+        d->ivr = 0xF;
 	d->port[0].mrp = 0;
 	d->port[0].sr = 0x00;
 	d->port[1].mrp = 0;


### PR DESCRIPTION
According to Section 2.4, "RESET" page 2-2 of
http://www.bitsavers.org/components/motorola/68000/MC68681_Dual_Asynchronous_Receiver_Transmitter_DUART_Sep85.pdf the interrupt vector register (IVA) is set to 0xF when the DUART is reset.

I've seen this reset value used in DUART detection schemes.